### PR TITLE
DAP integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,9 @@ SASS files are kept in the `/_sass` directory. To watch for changes and recompil
 ```
 npm run watch
 ```
+
+## Analytics
+
+The file `_includes/head.html` contains script tags for the following analytics tools:
+[Digital Analytics Program](https://digital.gov/guides/dap/)
+[Google Analytics](https://marketingplatform.google.com/about/analytics/)

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -24,4 +24,5 @@
 
     gtag('config', 'G-HYG1W60QS2');
   </script>
+  <script async type="text/javascript" id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=DOC&amp;subagency=CEN" async type="text/javascript"></script>
 </head>


### PR DESCRIPTION
## Description
Adds a script tag to head that loads the following JavaScript from the [Digital Analytics Program](https://digital.gov/guides/dap/): https://github.com/digital-analytics-program/gov-wide-code.

Resolves #53.

## Testing
N/A